### PR TITLE
VerticalStation

### DIFF
--- a/data/sites.csv
+++ b/data/sites.csv
@@ -2,6 +2,7 @@ domain,holder1,holder2,holder3,holder4
 lemonde.fr,Xavier Niel,,,
 tf1.fr,la famille Bouygues,,,
 lci.fr,la famille Bouygues,,,
+verticalstation.com,la famille Bouygues,,,
 lefigaro.fr,la famille Dassault,,,
 lalettredelexpansion.com,la famille Dassault,,,
 nouvelobs.com,Xavier Niel,,,


### PR DESCRIPTION
Mise à jour de VerticalStation (ex-minutebuzz) : https://www.verticalstation.com/

Source : 
- https://vl-media.fr/tf1-devient-actionnaire-minutebuzz/
- https://fr.wikipedia.org/wiki/Minutebuzz
- https://www.maddyness.com/2016/12/01/maddyflash-minutebuzz-tf1-actionnaire-majoritaire/